### PR TITLE
Update logstash-input-journald.gemspec

### DIFF
--- a/logstash-input-journald.gemspec
+++ b/logstash-input-journald.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 1.4.0'
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-codec-line'


### PR DESCRIPTION
removed the upper version boundary for the logstash-core requirement line.  builds and installs on updated RHEL7.2 after doing this.
